### PR TITLE
keychain: remove export * as ... syntax

### DIFF
--- a/packages/keychain/src/mod.ts
+++ b/packages/keychain/src/mod.ts
@@ -3,5 +3,6 @@ export * from "./algolist/mod";
 export * from "./cert/mod";
 export * from "./iv/mod";
 export * from "./key/mod";
-export * as CertNaming from "./naming";
+import * as CertNaming from "./naming";
+export { CertNaming };
 export * from "./store/mod";


### PR DESCRIPTION
This isn't ideal but `@microsoft/api-extractor` doesn't support this syntax for whatever reason. This blocks creation of user types in NDN Play so it either needs to be patched or not run in CI.

I understand if you don't want this change; feel free to close in that case.