### PR TITLE
Update ZenFS to stable versions

### DIFF
--- a/integ/browser-tests/package.json
+++ b/integ/browser-tests/package.json
@@ -25,8 +25,8 @@
   "devDependencies": {
     "@nodelib/fs.walk": "^2.0.0",
     "@types/webpack": "^5.28.5",
-    "@zenfs/core": "^0.12.10",
-    "@zenfs/dom": "^0.2.13",
+    "@zenfs/core": "^1.0.0",
+    "@zenfs/dom": "^1.0.0",
     "fork-ts-checker-webpack-plugin": "^9.0.2",
     "html-webpack-plugin": "^5.6.0",
     "puppeteer": "^22.12.1",

--- a/pkg/fileserver/package.json
+++ b/pkg/fileserver/package.json
@@ -32,7 +32,7 @@
     "@ndn/segmented-object": "workspace:*",
     "@ndn/tlv": "workspace:*",
     "@ndn/util": "workspace:*",
-    "@zenfs/core": "^0.12.10",
+    "@zenfs/core": "^1.0.0",
     "mnemonist": "^0.39.8",
     "obliterator": "^2.0.4",
     "streaming-iterables": "^8.0.1",

--- a/pkg/segmented-object/package.json
+++ b/pkg/segmented-object/package.json
@@ -31,7 +31,7 @@
     "@ndn/naming-convention2": "workspace:*",
     "@ndn/packet": "workspace:*",
     "@ndn/util": "workspace:*",
-    "@zenfs/core": "^0.12.10",
+    "@zenfs/core": "^1.0.0",
     "hirestime": "^7.0.4",
     "it-keepalive": "^1.2.0",
     "mnemonist": "^0.39.8",


### PR DESCRIPTION
This PR updates `@zenfs` packages to stable versions (i.e. `^1.0.0`).